### PR TITLE
feat: create board entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,30 @@
 version: '3.9'
 networks:
-  default:
-    external: false
-    name: board-app-local
+  board-app-local:
 
 services:
+  main:
+    container_name: board-nestjs
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: npm run start:dev
+    volumes:
+      - .:/usr/src/app
+      - /usr/src/app/node_modules
+    ports:
+      - 5000:5000
+    networks:
+      - board-app-local
+    depends_on:
+      - postgres
+
   postgres:
     image: postgres:13.2
     container_name: board-postgres
     restart: always
+    networks:
+      - board-app-local
     environment:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+networks:
+  default:
+    external: false
+    name: board-app-local
+
+services:
+  postgres:
+    image: postgres:13.2
+    container_name: board-postgres
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: board-postgres
+    ports:
+      - 5432:5432
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,7 @@ import { BoardsModule } from './boards/boards.module';
     BoardsModule,
     TypeOrmModule.forRoot({
       type: 'postgres',
-      host: 'localhost',
+      host: 'postgres',
       port: 5432,
       username: 'postgres',
       password: 'postgres',

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,7 @@ import { BoardsModule } from './boards/boards.module';
     BoardsModule,
     TypeOrmModule.forRoot({
       type: 'postgres',
-      host: 'postgres',
+      host: 'localhost',
       port: 5432,
       username: 'postgres',
       password: 'postgres',

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,7 @@ import { BoardsModule } from './boards/boards.module';
     BoardsModule,
     TypeOrmModule.forRoot({
       type: 'postgres',
-      host: 'localhost',
+      host: 'board-postgres',
       port: 5432,
       username: 'postgres',
       password: 'postgres',

--- a/src/boards/board.entity.ts
+++ b/src/boards/board.entity.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Board {
+  @PrimaryGeneratedColumn()
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column()
+  description: string;
+}

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -8,7 +8,7 @@ export class BoardsController {
 
   @Get()
   async getAllBoards(): Promise<Board[]> {
-    return await this.boardsService.getAllBoards();
+    return this.boardsService.getAllBoards();
   }
 
   @Post()

--- a/src/boards/boards.controller.ts
+++ b/src/boards/boards.controller.ts
@@ -7,12 +7,12 @@ export class BoardsController {
   constructor(private boardsService: BoardsService) {}
 
   @Get()
-  getAllBoards(): Board[] {
-    return this.boardsService.getAllBoards();
+  async getAllBoards(): Promise<Board[]> {
+    return await this.boardsService.getAllBoards();
   }
 
   @Post()
-  addBoard(@Req() request: Request): Board {
+  async addBoard(@Req() request: Request): Promise<Board> {
     const { title, description } = request.body;
     return this.boardsService.addBoard({ title, description });
   }

--- a/src/boards/boards.module.ts
+++ b/src/boards/boards.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Board } from './board.entity';
 import { BoardsController } from './boards.controller';
 import { BoardsService } from './boards.service';
 
 @Module({
-  imports: [],
+  imports: [TypeOrmModule.forFeature([Board])],
   controllers: [BoardsController],
   providers: [BoardsService],
 })

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { v1 as uuid } from 'uuid';
 import { Board as BoardEntity } from './board.entity';
 
 export interface Board {
@@ -17,22 +16,20 @@ export class BoardsService {
     private boardRepository: Repository<BoardEntity>,
   ) {}
 
-  private boards: Board[] = [];
-
-  getAllBoards() {
-    return this.boards;
+  async getAllBoards(): Promise<Board[]> {
+    return await this.boardRepository.find();
   }
 
-  addBoard({
+  async addBoard({
     title,
     description,
   }: {
     title: string;
     description: string;
-  }): Board {
-    const board = { id: uuid(), title, description };
-    this.boards.push(board);
+  }): Promise<Board> {
+    const board = { title, description };
+    const savedBoard = await this.boardRepository.save(board);
 
-    return board;
+    return savedBoard;
   }
 }

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -16,8 +16,8 @@ export class BoardsService {
     private boardRepository: Repository<BoardEntity>,
   ) {}
 
-  async getAllBoards(): Promise<Board[]> {
-    return await this.boardRepository.find();
+  getAllBoards(): Promise<Board[]> {
+    return this.boardRepository.find();
   }
 
   async addBoard({

--- a/src/boards/boards.service.ts
+++ b/src/boards/boards.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { v1 as uuid } from 'uuid';
+import { Board as BoardEntity } from './board.entity';
 
 export interface Board {
   id: string;
@@ -9,6 +12,11 @@ export interface Board {
 
 @Injectable()
 export class BoardsService {
+  constructor(
+    @InjectRepository(BoardEntity)
+    private boardRepository: Repository<BoardEntity>,
+  ) {}
+
   private boards: Board[] = [];
 
   getAllBoards() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(5000);
 }
 bootstrap();


### PR DESCRIPTION
### Learned
1) user-defined network

container 끼리 communicate 하기 위해서는 같은 network 내에 있어야 한다. 기본적으로 docker container를 실행시키면 docker 기본 네트워크인 `bridge`를 사용한다. 기본 bridge 네트워크에서는 container는 각각의 IP address가 있기 때문에 서로의 IP 주소를 사용하여 commuicate 할 수 있다.

기본 network 말고 user가 새로 network를 만들 수 있는데 이를 user-defined network라고 부른다. 해당 PR에서는 board-app-local 이라는 network를 만들어서 nestjs app과 postgres 가 서로 communicate 할 수 있도록 했다. container의 이름을 host로 사용하여 commuicate 할 수 있다는 장점이 있음!
예) postgres app과 NestJS 연결시 같은 네트워크에 있기 때문에 TypeORM config로 `host: postgres 컨테이너 이름` 으로 설정 가능

참고: https://www.tutorialworks.com/container-networking/

2) Board라는 Relation이 없는데?
![Screen Shot 2022-12-05 at 2 19 11 PM](https://user-images.githubusercontent.com/30627807/205555253-0e35b757-233e-4c19-a22f-cdfb340ff606.png)

새로운 entity가 생기면 TypeORM이 알아서 table을 만들 수 있도록 해줄 수 있다. TypeORM ormconfig 세팅으로 `synchronize: true`를 설정해주면 앱이 실행될 때마다 싱크가 되어 있는지 되지 않았는지 체크한다. 
production 환경에서는 데이터 유실 될 수 있으므로 false로 설정하긔.

참고: https://github.com/typeorm/typeorm/blob/master/docs/faq.md#how-do-i-update-a-database-schema

