### PR TITLE
fix: WORKDIR, volumes path can sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,6 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     volumes:
-      - ./frontend/src:/usr/src/frontend
+      - ./frontend:/usr/src/frontend
     ports:
       - 3000:3000

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16
-WORKDIR /usr/src/app
+WORKDIR /usr/src/frontend
 COPY package*.json ./
 RUN npm install
 COPY . .


### PR DESCRIPTION
resolves #9 

### But, 아직 의문
- volumes은 container가 사용하고 있는 data를 유지시키기 위해서 사용된다. 예를 들어 db 데이터가 있는데 매번 container가 실행될 때마다 db에 저장한 데이터가 날아가면 불편할 것임. 이럴 때 volume을 사용해서 database에 저장된 data는 계속 유지되도록 만들 수 있다.
- react app은 development 모드에서 변경 사항들이 있으면 해당 변경 사항을 바로 화면에 보여주기 위한 auto reload 기능을 제공해준다. 이때 대부분의 예제에서 container 환경에서도 auto reload가 가능하게 하기 위해서 volume을 사용한다. container는 Dockerfile을 통해서 빌드한 이미지를 실행시키기 때문에 빌드할 당시의 소스 코드를 사용해서 앱을 실행시킨다. 따라서 host machine에서 개발자가 코드를 변경하더라도 container는 모른다. container에게 source code가 변경되었다는 걸 알려주기 위해서 volume을 사용한다.

근데 docker 문서를 보면 bind mounts 개념이 더 적합한거 같아서 헷갈린다. 내가 아직 두 차이를 정확하게 이해하지 않은거 일 수도 👀