### PR TITLE
refactor: user find or create

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,9 +10,11 @@ import { GoogleAuthController } from './controllers/google.auth.controller';
 import { GoogleStrategy } from './strategies/google.strategy';
 import { FacebookOAuthController } from './controllers/facebook.oauth.controller';
 import { FacebookStrategy } from './strategies/facebook.strategy';
+import { ValidateUserUseCase } from './usecases/validateUser.usecase';
+import { TokenModule } from 'src/token/token.module';
 
 @Module({
-  imports: [JwtAuthModule, UserModule, HttpModule],
+  imports: [JwtAuthModule, UserModule, HttpModule, TokenModule],
   controllers: [
     OpenBankingOAuthController,
     AuthController,
@@ -24,6 +26,7 @@ import { FacebookStrategy } from './strategies/facebook.strategy';
     LocalAuthStrategy,
     GoogleStrategy,
     FacebookStrategy,
+    ValidateUserUseCase,
   ],
 })
 export class AuthModule {}

--- a/backend/src/auth/controllers/auth.controller.ts
+++ b/backend/src/auth/controllers/auth.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
 import { UserService } from 'src/user/user.service';
 import { LocalAuthGuard } from '../guards/local.auth.guard';
 import { JwtAuthGuard } from '../guards/jwt.auth.guard';
@@ -9,7 +8,6 @@ import { JwtAuthService } from '../services/jwt-auth.service';
 export class AuthController {
   constructor(
     private readonly userService: UserService,
-    private readonly jwtService: JwtService,
     private readonly jwtAuthService: JwtAuthService,
   ) {}
 

--- a/backend/src/auth/controllers/google.auth.controller.ts
+++ b/backend/src/auth/controllers/google.auth.controller.ts
@@ -8,10 +8,8 @@ export class GoogleAuthController {
   constructor(private readonly jwtAuthService: JwtAuthService) {}
 
   @Get()
-  @UseGuards(GoogleOauthGuard) // ?: Strategy만 연결했는데 어떻게 google oauth server로 찾아가는거지?
-  async googleAuth(@Req() req) {
-    // Guard가 Redirect 함
-  }
+  @UseGuards(GoogleOauthGuard)
+  async googleAuth(@Req() req) {}
 
   @Get('redirect')
   @UseGuards(GoogleOauthGuard)

--- a/backend/src/auth/controllers/openbanking.oauth.controller.ts
+++ b/backend/src/auth/controllers/openbanking.oauth.controller.ts
@@ -9,6 +9,7 @@ import {
   OpenBankingProfile,
 } from '../authProfile';
 import { JwtAuthService } from '../services/jwt-auth.service';
+import { ValidateUserUseCase } from '../usecases/validateUser.usecase';
 
 @Controller('auth/open-banking')
 export class OpenBankingOAuthController {
@@ -17,6 +18,7 @@ export class OpenBankingOAuthController {
     private readonly configService: ConfigService,
     private readonly userService: UserService,
     private readonly jwtAuthService: JwtAuthService,
+    private validateUserUseCase: ValidateUserUseCase,
   ) {}
 
   @Get()
@@ -50,8 +52,11 @@ export class OpenBankingOAuthController {
     // signUp시에는 이 jwtAuthGuard로 막아놓으면 됨.
 
     const openBankingProfile = new OpenBankingProfile(data);
-    const user = await this.userService._findOrCreate(
-      openBankingProfile.convertToOAuthProfile(),
+    const oauthProfile = openBankingProfile.convertToOAuthProfile();
+    const user = await this.validateUserUseCase.execute(
+      oauthProfile,
+      oauthProfile.accessToken,
+      oauthProfile.refreshToken,
     );
 
     const { accessToken } = await this.jwtAuthService.login({

--- a/backend/src/auth/controllers/openbanking.oauth.controller.ts
+++ b/backend/src/auth/controllers/openbanking.oauth.controller.ts
@@ -2,12 +2,7 @@ import { Controller, Get, Query, Req, Res } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
-import { UserService } from 'src/user/user.service';
-import {
-  IdentityProvider,
-  IOpenBankingProfile,
-  OpenBankingProfile,
-} from '../authProfile';
+import { IOpenBankingProfile, OpenBankingProfile } from '../authProfile';
 import { JwtAuthService } from '../services/jwt-auth.service';
 import { ValidateUserUseCase } from '../usecases/validateUser.usecase';
 
@@ -16,7 +11,6 @@ export class OpenBankingOAuthController {
   constructor(
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
-    private readonly userService: UserService,
     private readonly jwtAuthService: JwtAuthService,
     private validateUserUseCase: ValidateUserUseCase,
   ) {}

--- a/backend/src/auth/controllers/openbanking.oauth.controller.ts
+++ b/backend/src/auth/controllers/openbanking.oauth.controller.ts
@@ -43,15 +43,9 @@ export class OpenBankingOAuthController {
       },
     );
 
-    // signUp시에는 이 jwtAuthGuard로 막아놓으면 됨.
-
     const openBankingProfile = new OpenBankingProfile(data);
     const oauthProfile = openBankingProfile.convertToOAuthProfile();
-    const user = await this.validateUserUseCase.execute(
-      oauthProfile,
-      oauthProfile.accessToken,
-      oauthProfile.refreshToken,
-    );
+    const user = await this.validateUserUseCase.execute(oauthProfile);
 
     const { accessToken } = await this.jwtAuthService.login({
       id: user.id,

--- a/backend/src/auth/strategies/facebook.strategy.ts
+++ b/backend/src/auth/strategies/facebook.strategy.ts
@@ -3,7 +3,6 @@ import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-facebook';
 import { IUser } from 'src/user/user.model';
-import { UserService } from 'src/user/user.service';
 import { FacebookProfile, IFacebookProfile } from '../authProfile';
 import { ValidateUserUseCase } from '../usecases/validateUser.usecase';
 

--- a/backend/src/auth/strategies/facebook.strategy.ts
+++ b/backend/src/auth/strategies/facebook.strategy.ts
@@ -33,8 +33,6 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
 
     const user = await this.validateUserUseCase.execute(
       facebookProfile.convertToOAuthProfile(accessToken, refreshToken),
-      accessToken,
-      refreshToken,
     );
 
     return user;

--- a/backend/src/auth/strategies/facebook.strategy.ts
+++ b/backend/src/auth/strategies/facebook.strategy.ts
@@ -5,12 +5,13 @@ import { Strategy } from 'passport-facebook';
 import { IUser } from 'src/user/user.model';
 import { UserService } from 'src/user/user.service';
 import { FacebookProfile, IFacebookProfile } from '../authProfile';
+import { ValidateUserUseCase } from '../usecases/validateUser.usecase';
 
 @Injectable()
 export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
   constructor(
     configService: ConfigService,
-    private readonly userService: UserService,
+    private validateUserUseCase: ValidateUserUseCase,
   ) {
     super({
       clientID: configService.get<string>('FACEBOOK_CLIENT_ID'),
@@ -30,8 +31,10 @@ export class FacebookStrategy extends PassportStrategy(Strategy, 'facebook') {
     }
     const facebookProfile = new FacebookProfile(profile);
 
-    const user = await this.userService._findOrCreate(
+    const user = await this.validateUserUseCase.execute(
       facebookProfile.convertToOAuthProfile(accessToken, refreshToken),
+      accessToken,
+      refreshToken,
     );
 
     return user;

--- a/backend/src/auth/strategies/google.strategy.ts
+++ b/backend/src/auth/strategies/google.strategy.ts
@@ -5,10 +5,14 @@ import { ConfigService } from '@nestjs/config';
 import { UserService } from 'src/user/user.service';
 import { IUser } from 'src/user/user.model';
 import { GoogleProfile, IGoogleProfile } from '../authProfile';
+import { ValidateUserUseCase } from '../usecases/validateUser.usecase';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
-  constructor(configService: ConfigService, private userService: UserService) {
+  constructor(
+    configService: ConfigService,
+    private validateUserUseCase: ValidateUserUseCase,
+  ) {
     super({
       clientID: configService.get<string>('GOOGLE_CLIENT_ID'),
       clientSecret: configService.get<string>('GOOGLE_SECRET'),
@@ -24,8 +28,10 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
   ): Promise<IUser> {
     const googleProfile = new GoogleProfile(profile);
 
-    const user = await this.userService._findOrCreate(
-      googleProfile.convertToOAuthProfile(accessToken, refreshToken),
+    const user = await this.validateUserUseCase.execute(
+      googleProfile.convertToOAuthProfile(accessToken, refreshToken), // TODO: 변경
+      accessToken,
+      refreshToken,
     );
 
     return user;

--- a/backend/src/auth/strategies/google.strategy.ts
+++ b/backend/src/auth/strategies/google.strategy.ts
@@ -29,9 +29,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
     const googleProfile = new GoogleProfile(profile);
 
     const user = await this.validateUserUseCase.execute(
-      googleProfile.convertToOAuthProfile(accessToken, refreshToken), // TODO: 변경
-      accessToken,
-      refreshToken,
+      googleProfile.convertToOAuthProfile(accessToken, refreshToken),
     );
 
     return user;

--- a/backend/src/auth/strategies/google.strategy.ts
+++ b/backend/src/auth/strategies/google.strategy.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-google-oauth20';
 import { ConfigService } from '@nestjs/config';
-import { UserService } from 'src/user/user.service';
 import { IUser } from 'src/user/user.model';
 import { GoogleProfile, IGoogleProfile } from '../authProfile';
 import { ValidateUserUseCase } from '../usecases/validateUser.usecase';

--- a/backend/src/auth/usecases/validateUser.usecase.ts
+++ b/backend/src/auth/usecases/validateUser.usecase.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { TokenService } from 'src/token/token.service';
+import { IUser, OAuthProfile } from 'src/user/user.model';
+import { UserService } from 'src/user/user.service';
+
+@Injectable()
+export class ValidateUserUseCase {
+  constructor(
+    private userService: UserService,
+    private tokenService: TokenService,
+  ) {}
+
+  async execute(
+    profile: OAuthProfile,
+    accessToken: string,
+    refreshToken: string,
+  ): Promise<IUser> {
+    const user = await this.userService.findOne({ localId: profile.localId });
+
+    if (user) {
+      return {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+      };
+    }
+
+    const savedToken = await this.tokenService.save(accessToken, refreshToken);
+    const savedUser = await this.userService.createUser(profile, savedToken);
+
+    return savedUser;
+  }
+}

--- a/backend/src/auth/usecases/validateUser.usecase.ts
+++ b/backend/src/auth/usecases/validateUser.usecase.ts
@@ -10,11 +10,7 @@ export class ValidateUserUseCase {
     private tokenService: TokenService,
   ) {}
 
-  async execute(
-    profile: OAuthProfile,
-    accessToken: string,
-    refreshToken: string,
-  ): Promise<IUser> {
+  async execute(profile: OAuthProfile): Promise<IUser> {
     const user = await this.userService.findOne({ localId: profile.localId });
 
     if (user) {
@@ -25,7 +21,10 @@ export class ValidateUserUseCase {
       };
     }
 
-    const savedToken = await this.tokenService.save(accessToken, refreshToken);
+    const savedToken = await this.tokenService.save(
+      profile.accessToken,
+      profile.refreshToken,
+    );
     const savedUser = await this.userService.createUser(profile, savedToken);
 
     return savedUser;

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -28,10 +28,6 @@ export class UserService {
       };
     }
 
-    // 이 함수의 가장 큰 문제는 계층이 같은 service 함수를 가져와서 썼다는 것임. 계층이 옆으로 참조하는게 아니라 아래의 함수를 사용해야함. 왜?
-
-    // 함수는 user, profile 둘다 다루고 있다. 함수가 해야할 역할이 사실 상 두개인 것임. (user 생성, 토큰 생성)
-    // user는 토큰에 대한 정보를 몰라도 된다. tokenService에서 다루는 token의 형태가 바뀌었을 때 userService까지 영향을 미치게 되는 것이다.
     const savedUser = await this.saveProfile(oauthProfile);
 
     return savedUser;

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcryptjs';
+import { Token } from 'src/token/token.entity';
 import { TokenService } from 'src/token/token.service';
 import { Repository } from 'typeorm';
 import { User } from './user.entity';
@@ -27,6 +28,10 @@ export class UserService {
       };
     }
 
+    // 이 함수의 가장 큰 문제는 계층이 같은 service 함수를 가져와서 썼다는 것임. 계층이 옆으로 참조하는게 아니라 아래의 함수를 사용해야함. 왜?
+
+    // 함수는 user, profile 둘다 다루고 있다. 함수가 해야할 역할이 사실 상 두개인 것임. (user 생성, 토큰 생성)
+    // user는 토큰에 대한 정보를 몰라도 된다. tokenService에서 다루는 token의 형태가 바뀌었을 때 userService까지 영향을 미치게 되는 것이다.
     const savedUser = await this.saveProfile(oauthProfile);
 
     return savedUser;
@@ -45,6 +50,25 @@ export class UserService {
       provider: oauthProfile.provider,
       localId: oauthProfile.localId,
       token: tokenIssuedByIdentityProvider,
+    });
+
+    const saved = await this.userRepository.save(user);
+
+    return {
+      id: saved.id,
+      name: saved.name,
+      email: saved.email,
+    };
+  }
+
+  async createUser(profile: OAuthProfile, token: Token): Promise<UserModel> {
+    const user = await this.userRepository.create({
+      name: profile.name,
+      email: profile.email,
+      photo: profile.photo,
+      provider: profile.provider,
+      localId: profile.localId,
+      token,
     });
 
     const saved = await this.userRepository.save(user);
@@ -89,7 +113,7 @@ export class UserService {
     const user = await this.userRepository.findOne({ where: condition });
 
     if (!user) {
-      throw new Error('Can not find user.');
+      return null; // service에서는 error를 던지지 않나 보통?
     }
 
     // TODO: user 모델 통일 필요

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcryptjs';
 import { Token } from 'src/token/token.entity';
-import { TokenService } from 'src/token/token.service';
 import { Repository } from 'typeorm';
 import { User } from './user.entity';
 import { OAuthProfile, IUser as UserModel } from './user.model';
@@ -12,50 +11,7 @@ export class UserService {
   constructor(
     @InjectRepository(User)
     private userRepository: Repository<User>,
-    private tokenService: TokenService,
   ) {}
-
-  async _findOrCreate(oauthProfile: OAuthProfile): Promise<UserModel> {
-    const user = await this.userRepository.findOneBy({
-      localId: oauthProfile.localId,
-    });
-
-    if (user) {
-      return {
-        id: user.id,
-        name: user.name,
-        email: user.email,
-      };
-    }
-
-    const savedUser = await this.saveProfile(oauthProfile);
-
-    return savedUser;
-  }
-
-  async saveProfile(oauthProfile: OAuthProfile): Promise<UserModel> {
-    const tokenIssuedByIdentityProvider = await this.tokenService.save(
-      oauthProfile.accessToken,
-      oauthProfile.refreshToken,
-    );
-
-    const user = await this.userRepository.create({
-      name: oauthProfile.name,
-      email: oauthProfile.email,
-      photo: oauthProfile.photo,
-      provider: oauthProfile.provider,
-      localId: oauthProfile.localId,
-      token: tokenIssuedByIdentityProvider,
-    });
-
-    const saved = await this.userRepository.save(user);
-
-    return {
-      id: saved.id,
-      name: saved.name,
-      email: saved.email,
-    };
-  }
 
   async createUser(profile: OAuthProfile, token: Token): Promise<UserModel> {
     const user = await this.userRepository.create({


### PR DESCRIPTION
이 함수의 가장 큰 문제는 계층이 같은 service 함수를 가져와서 썼다는 것임. 계층이 옆으로 참조하는게 아니라 아래의 함수를 사용해야함. (왜?)

- 함수는 user, profile 둘다 다루고 있다. 함수가 해야할 역할이 사실 상 두개인 것임. (user 생성, 토큰 생성)
- user는 토큰에 대한 정보를 몰라도 된다. tokenService에서 다루는 token의 형태가 바뀌었을 때 userService까지 영향을 미치게 된다.